### PR TITLE
Update GNU Embedded Toolchain, 8-2018-q4-major

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # docker
-Docker images to enable automated builds
+Docker Hub can automatically build images from source code in my github repository included multiple Dockerfiles and automatically push the built image to my Docker repositories.
+
+### Set Dockerfile location
+- Docker Hub can specify the **Dockerfile location** as a path relative to the build context.
+- If the Dockerfile is at the root of ther build context path, leave the Dockerfile path set to `/`.
+(If the build context field is blank, set the path to the Dockerfile from the root of the source repository.)

--- a/gnu-arm-embedded/Dockerfile
+++ b/gnu-arm-embedded/Dockerfile
@@ -10,13 +10,13 @@ RUN apt update && \
     apt upgrade -y && \
     apt install -y \
 # Development files
-      build-essential \
-      git \
-      bzip2 \
-      wget && \
+    build-essential \
+    git \
+    bzip2 \
+    wget && \
     apt clean && \
-    wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2 -O cortex_m.tar.bz2 && \
+    wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2 -O cortex_m.tar.bz2 && \
     tar -xjf cortex_m.tar.bz2 && \
     rm cortex_m.tar.bz2
 
-ENV PATH "/work/gcc-arm-none-eabi-7-2017-q4-major/bin:$PATH"
+ENV PATH "/work/gcc-arm-none-eabi-8-2018-q4-major/bin:$PATH"


### PR DESCRIPTION
GNU Arm Embedded Toolchain: 8-2018-q4-major - December 20, 2018

Features
- All GCC 8 features, plus latest mainline features

Known Changes and Issues
- Thumb1 code size regression due to new register allocation: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59535
- Multilib is now enabled with --with-multilib-list=rmprofile when building the toolchain from source
- Windows installer now accepts the following options when running in silent mode:
  - /P Adds the installation bin directory to the system PATH
  - /R Adds an InstallFolder registry entry for the install.